### PR TITLE
[FEATURE][EVENTSINFO][API] 얼리버드 공연/전시 정보 등록페이지 비활성화 에러 해결

### DIFF
--- a/src/pages/EventsInfo/Events.js
+++ b/src/pages/EventsInfo/Events.js
@@ -57,7 +57,7 @@ function Events() {
     handleSearch();
   };
 
-  // 수정 버튼 클릭 핸들러
+  // 등록 버튼 클릭 핸들러
   const handleRegisterClick = (id, type) => {
     navigate(`/events/${id}`, {state: {type}});
   };

--- a/src/pages/EventsInfo/Events.js
+++ b/src/pages/EventsInfo/Events.js
@@ -57,6 +57,11 @@ function Events() {
     handleSearch();
   };
 
+  // 수정 버튼 클릭 핸들러
+  const handleRegisterClick = (id, type) => {
+    navigate(`/events/${id}`, {state: {type}});
+  };
+
   const navigate = useNavigate();
 
   // 현재 페이지에 표시할 이벤트 계산
@@ -67,7 +72,8 @@ function Events() {
       <Box className="header-container">
         <Typography variant="h5" className="table-titles">얼리버드 공연/전시</Typography>
          <Box className="actions-container">
-          <Button variant="outlined" className="register-button" onClick={() => navigate(`/events/new`, {state: "register"})}>등록</Button>
+          <Button variant="outlined" className="register-button" onClick={() => handleRegisterClick("new","register")}>등록</Button>
+          {/* navigate(`/events/new`, {state: "register"}) */}
           <Box className="search-box">
             <InputBase
               className="search-input"


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[FEATURE][EVENTSINFO][API]

### 💡 작업동기
- 얼리버드 공연/전시 정보 메인 페이지에서 등록버튼 클릭시, 등록 페이지 입력content 영역이 보이지 않는 에러 해결하는 작업입니다.

### 🔑 주요 변경사항
- Event.js 내, 등록버튼 관련 코드 변경

### 🏞 스크린샷
### Event.js 내, 등록버튼 관련 코드 변경
![image](https://github.com/S-O-O-P/S-O-O-P-React-Admin/assets/73331620/ebb2dd6d-7735-44f9-b58d-3114db718a84)

### 관련 이슈
- 관련 이슈를 입력해주세요.

### 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
